### PR TITLE
Add GPT-4 summary options for cloud transcription

### DIFF
--- a/server.py
+++ b/server.py
@@ -91,6 +91,22 @@ LANGS: Dict[str, str] = {
 DEFAULT_LANG = "Français"
 DEFAULT_MODEL_LOCAL = "Large v3 (CPU lourd)"
 
+# — prompts selon le format de sortie désiré
+OUTPUT_PROMPTS: Dict[str, str] = {
+    "resume": (
+        "Résume le texte suivant en français, sans phrase d'introduction ni conclusion:\n{texte}"
+    ),
+    "compte_rendu": (
+        "Rédige un compte-rendu en français du texte suivant, sans phrase d'introduction ni conclusion:\n{texte}"
+    ),
+    "cahier_des_charges": (
+        "À partir du texte suivant, rédige un cahier des charges en français, sans phrase d'introduction ni conclusion:\n{texte}"
+    ),
+    "notes_de_cadrage": (
+        "À partir du texte suivant, rédige des notes de cadrage en français, sans phrase d'introduction ni conclusion:\n{texte}"
+    ),
+}
+
 # — tailles approximatives pour le suivi de progression (octets)
 #   valeurs proches des poids CTranslate2 (pratique pour une jauge réaliste)
 MODEL_APPROX_SIZE = {
@@ -154,6 +170,7 @@ async def transcribe_endpoint(
     api_key: Optional[str] = Form(None),
     model_label: str = Form(...),
     lang_label: str = Form(...),
+    output_type: str = Form("resume"),
     files: List[UploadFile] = File(...),
 ):
     if not files:
@@ -175,6 +192,9 @@ async def transcribe_endpoint(
     if lang_label not in LANGS:
         raise HTTPException(status_code=400, detail="Langue inconnue")
     lang_code = LANGS[lang_label]
+
+    if output_type not in OUTPUT_PROMPTS:
+        raise HTTPException(status_code=400, detail="Format de sortie inconnu")
 
     job_id = str(uuid.uuid4())
     job_upload_dir = UPLOAD_DIR / job_id
@@ -202,6 +222,7 @@ async def transcribe_endpoint(
         "use_api": use_api_bool,
         "model": model_name,
         "lang": lang_code,
+        "output_type": output_type,
         "progress": 0.0,
         "logs": [f"Job {job_id} créé avec {len(files_meta)} fichier(s)."],
         "files": files_meta,
@@ -310,6 +331,7 @@ def _run_cloud(job_id: str, client: "OpenAI"):
     total = len(job["files"])
     model_name = job["model"]
     lang = job["lang"]
+    output_type = job.get("output_type", "resume")
 
     for idx, fmeta in enumerate(job["files"]):
         update_file_status(job_id, idx, "running")
@@ -323,16 +345,27 @@ def _run_cloud(job_id: str, client: "OpenAI"):
                 )
             text = (getattr(resp, "text", "") or "").strip()
 
+            processed = text
+            prompt_tmpl = OUTPUT_PROMPTS.get(output_type)
+            if prompt_tmpl and text:
+                append_log(job_id, f"→ GPT-4 pour '{output_type}'")
+                prompt = prompt_tmpl.format(texte=text)
+                resp2 = client.responses.create(model="gpt-4o", input=prompt)
+                processed = (getattr(resp2, "output_text", "") or "").strip()
+
             out_dir = TRANS_DIR / job_id
             out_dir.mkdir(parents=True, exist_ok=True)
             out_file = out_dir / (pathlib.Path(fmeta["name"]).stem + ".txt")
-            out_file.write_text("\n".join(full_text).strip() + "\n", encoding="utf-8")
+            out_file.write_text(
+                processed + ("\n" if processed and not processed.endswith("\n") else ""),
+                encoding="utf-8",
+            )
 
             set_file_output(job_id, idx, str(out_file))
             set_file_progress(job_id, idx, 1.0)                    # <— ajout
             set_job_progress(job_id, (idx + 1) / max(total, 1))    # <— ajout
             update_file_status(job_id, idx, "done")
-            append_log(job_id, f"✓ Terminé (local) : {fmeta['name']} → {out_file.name}")
+            append_log(job_id, f"✓ Terminé (API) : {fmeta['name']} → {out_file.name}")
 
         except Exception as e:
             update_file_status(job_id, idx, "error", error=str(e))

--- a/static/app.js
+++ b/static/app.js
@@ -3,6 +3,8 @@ const form = document.getElementById("form");
 const modeSelect = document.getElementById("mode");
 const apiKeyWrap = document.getElementById("api-key-wrap");
 const apiKeyInput = document.getElementById("api_key");
+const outputTypeWrap = document.getElementById("output-type-wrap");
+const outputTypeSelect = document.getElementById("output_type");
 
 const modelSelect = document.getElementById("model");
 const langSelect = document.getElementById("lang");
@@ -66,7 +68,9 @@ function fillModelOptions() {
     modelSelect.appendChild(opt);
   });
 
-  apiKeyWrap.style.display = useAPI ? "flex" : "none";
+  apiKeyWrap.hidden = !useAPI;
+  outputTypeWrap.hidden = !useAPI;
+  outputTypeSelect.disabled = !useAPI;
 }
 function fillLangOptions() {
   langSelect.innerHTML = "";
@@ -224,6 +228,7 @@ form.addEventListener("submit", async (e) => {
   fd.append("api_key", (apiKeyInput.value || "").trim());
   fd.append("model_label", modelSelect.value);
   fd.append("lang_label", langSelect.value);
+  fd.append("output_type", outputTypeSelect.value);
   Array.from(filesInput.files).forEach(f => fd.append("files", f, f.name));
 
   try {

--- a/templates/index.html
+++ b/templates/index.html
@@ -133,9 +133,19 @@
           </select>
         </div>
 
-        <div class="field" id="api-key-wrap" style="display:none">
+        <div class="field" id="api-key-wrap" hidden>
           <label for="api_key">Clé API OpenAI (facultatif si OPENAI_API_KEY est défini)</label>
           <input id="api_key" name="api_key" type="password" placeholder="sk-..." />
+        </div>
+
+        <div class="field" id="output-type-wrap" hidden>
+          <label for="output_type">Format de sortie</label>
+          <select id="output_type" name="output_type">
+            <option value="resume">Résumé</option>
+            <option value="compte_rendu">Compte-rendu</option>
+            <option value="cahier_des_charges">Cahier des charges</option>
+            <option value="notes_de_cadrage">Notes de cadrage</option>
+          </select>
         </div>
 
         <div class="field">


### PR DESCRIPTION
## Summary
- Hide API-only fields until OpenAI mode is chosen and disable output format selector otherwise
- Use the `hidden` attribute for reliable toggling of API key and output format sections

## Testing
- `python -m py_compile server.py`
- `python -m py_compile main_gui.py`


------
https://chatgpt.com/codex/tasks/task_b_68a6e482d7d08333a0a3582f1b980afe