### PR TITLE
Add GPT-4 summary options for cloud transcription

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3,6 +3,8 @@ const form = document.getElementById("form");
 const modeSelect = document.getElementById("mode");
 const apiKeyWrap = document.getElementById("api-key-wrap");
 const apiKeyInput = document.getElementById("api_key");
+const outputTypeWrap = document.getElementById("output-type-wrap");
+const outputTypeSelect = document.getElementById("output_type");
 
 const modelSelect = document.getElementById("model");
 const langSelect = document.getElementById("lang");
@@ -66,7 +68,8 @@ function fillModelOptions() {
     modelSelect.appendChild(opt);
   });
 
-  apiKeyWrap.style.display = useAPI ? "flex" : "none";
+  apiKeyWrap.hidden = !useAPI;
+  outputTypeWrap.hidden = !useAPI;
 }
 function fillLangOptions() {
   langSelect.innerHTML = "";
@@ -224,6 +227,9 @@ form.addEventListener("submit", async (e) => {
   fd.append("api_key", (apiKeyInput.value || "").trim());
   fd.append("model_label", modelSelect.value);
   fd.append("lang_label", langSelect.value);
+  if (use_api) {
+    fd.append("output_type", outputTypeSelect.value);
+  }
   Array.from(filesInput.files).forEach(f => fd.append("files", f, f.name));
 
   try {

--- a/templates/index.html
+++ b/templates/index.html
@@ -133,9 +133,19 @@
           </select>
         </div>
 
-        <div class="field" id="api-key-wrap" style="display:none">
+        <div class="field" id="api-key-wrap" hidden>
           <label for="api_key">Clé API OpenAI (facultatif si OPENAI_API_KEY est défini)</label>
           <input id="api_key" name="api_key" type="password" placeholder="sk-..." />
+        </div>
+
+        <div class="field" id="output-type-wrap" hidden>
+          <label for="output_type">Format de sortie</label>
+          <select id="output_type" name="output_type">
+            <option value="resume">Résumé</option>
+            <option value="compte_rendu">Compte-rendu</option>
+            <option value="cahier_des_charges">Cahier des charges</option>
+            <option value="notes_de_cadrage">Notes de cadrage</option>
+          </select>
         </div>
 
         <div class="field">


### PR DESCRIPTION
## Summary
- Hide API-only output format selector unless OpenAI mode is selected
- Send output format only for API jobs and default to "resume" locally

## Testing
- `python -m py_compile server.py`
- `python -m py_compile main_gui.py`


------
https://chatgpt.com/codex/tasks/task_b_68a6e482d7d08333a0a3582f1b980afe