### PR TITLE
Masquer la sélection du format de sortie en mode local

### DIFF
--- a/server.py
+++ b/server.py
@@ -170,7 +170,7 @@ async def transcribe_endpoint(
     api_key: Optional[str] = Form(None),
     model_label: str = Form(...),
     lang_label: str = Form(...),
-    output_type: str = Form("resume"),
+    output_type: Optional[str] = Form(None),
     files: List[UploadFile] = File(...),
 ):
     if not files:
@@ -193,8 +193,13 @@ async def transcribe_endpoint(
         raise HTTPException(status_code=400, detail="Langue inconnue")
     lang_code = LANGS[lang_label]
 
-    if output_type not in OUTPUT_PROMPTS:
-        raise HTTPException(status_code=400, detail="Format de sortie inconnu")
+    if use_api_bool:
+        if not output_type:
+            output_type = "resume"
+        if output_type not in OUTPUT_PROMPTS:
+            raise HTTPException(status_code=400, detail="Format de sortie inconnu")
+    else:
+        output_type = None
 
     job_id = str(uuid.uuid4())
     job_upload_dir = UPLOAD_DIR / job_id

--- a/static/app.js
+++ b/static/app.js
@@ -227,7 +227,7 @@ form.addEventListener("submit", async (e) => {
   fd.append("api_key", (apiKeyInput.value || "").trim());
   fd.append("model_label", modelSelect.value);
   fd.append("lang_label", langSelect.value);
-  fd.append("output_type", outputTypeSelect.value);
+  if (use_api) fd.append("output_type", outputTypeSelect.value);
   Array.from(filesInput.files).forEach(f => fd.append("files", f, f.name));
 
   try {


### PR DESCRIPTION
## Résumé
- Rend optionnel `output_type` côté serveur et l'ignore pour les transcriptions locales
- N'envoie le format de sortie que pour le mode API dans le client web

## Tests
- `python -m py_compile server.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a7141f311c8333bf3ec2f82e7be7c0