### PR TITLE
Boutons de téléchargement selon le mode de transcription

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -19,8 +19,12 @@ const jobStateSpan = document.getElementById("job-state");
 const filesList = document.getElementById("files-list");
 const logsPre = document.getElementById("logs");
 const downloadWrap = document.getElementById("downloads");
+const summaryBtn = document.getElementById("btn-summary");
 
 const themeBtn = document.getElementById("toggle-theme");
+
+// Masquer les boutons de téléchargement tant que la transcription n'est pas terminée
+downloadWrap.hidden = true;
 
 // ====== État local ======
 let pollTimer = null;
@@ -120,14 +124,14 @@ async function downloadZip(jobId) {
 }
 window.downloadZip = downloadZip;
 
-async function downloadTxt(jobId, merge = true) {
+async function downloadTxt(jobId, kind = 'transcription', merge = true) {
   try {
-    const res = await fetch(`/api/download-txt/${jobId}?merge=${merge ? 1 : 0}`, { method: 'GET', cache: 'no-store' });
+    const res = await fetch(`/api/download-txt/${jobId}?merge=${merge ? 1 : 0}&kind=${kind}`, { method: 'GET', cache: 'no-store' });
     if (!res.ok) { alert(`Échec TXT (${res.status}).`); return; }
     const blob = await res.blob();
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
-    a.href = url; a.download = `transcriptions_${jobId}.txt`;
+    a.href = url;
     document.body.appendChild(a); a.click(); a.remove();
     URL.revokeObjectURL(url);
   } catch (e) { alert('Échec du téléchargement TXT : ' + e); }
@@ -223,11 +227,12 @@ form.addEventListener("submit", async (e) => {
 
   const fd = new FormData();
   const use_api = modeSelect.value === "api";
+  summaryBtn.style.display = use_api ? "inline-flex" : "none";
   fd.append("use_api", use_api ? "1" : "0");
   fd.append("api_key", (apiKeyInput.value || "").trim());
   fd.append("model_label", modelSelect.value);
   fd.append("lang_label", langSelect.value);
-  fd.append("output_type", outputTypeSelect.value);
+  if (use_api) fd.append("output_type", outputTypeSelect.value);
   Array.from(filesInput.files).forEach(f => fd.append("files", f, f.name));
 
   try {
@@ -265,6 +270,7 @@ resetBtn.addEventListener("click", () => {
   filesList.innerHTML = "";
   progressBar.style.width = "0%";
   downloadWrap.hidden = true;
+  summaryBtn.style.display = "none";
 
   // Remettre les options par défaut
   fillModelOptions();

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,6 +31,7 @@
       }
 
       html, body { height: 100%; }
+      [hidden] { display: none !important; }
       body {
         margin: 0;
         background: var(--bg);
@@ -180,9 +181,10 @@
         <div id="files-list" class="files-list"></div>
         <pre id="logs" class="logs"></pre>
 
-        <div id="downloads" class="actions" style="display:flex; gap:.5rem;">
-          <button class="button" onclick="downloadZip(currentJobId)">Télécharger en ZIP</button>
-          <button class="button ghost" onclick="downloadTxt(currentJobId, true)">Télécharger en TXT</button>
+        <div id="downloads" class="actions" style="gap:.5rem;" hidden>
+          <button class="button ghost" id="btn-transcription" onclick="downloadTxt(currentJobId, 'transcription', true)">Télécharger la transcription (TXT)</button>
+          <button class="button ghost" id="btn-summary" style="display:none;" onclick="downloadTxt(currentJobId, 'summary', true)">Télécharger le résumé (TXT)</button>
+          <button class="button" id="btn-zip" onclick="downloadZip(currentJobId)">Télécharger en ZIP</button>
         </div>
       </section>
     </main>


### PR DESCRIPTION
## Résumé
- Assure que l'attribut `hidden` masque réellement les boutons de téléchargement jusqu'à la fin
- Préserve la disposition flex des boutons de téléchargement sans les afficher prématurément

## Tests
- `python -m py_compile server.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a7141f311c8333bf3ec2f82e7be7c0