### PR TITLE
Boutons de téléchargement selon le mode de transcription

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -31,6 +31,7 @@
       }
 
       html, body { height: 100%; }
+      [hidden] { display: none !important; }
       body {
         margin: 0;
         background: var(--bg);
@@ -180,9 +181,10 @@
         <div id="files-list" class="files-list"></div>
         <pre id="logs" class="logs"></pre>
 
-        <div id="downloads" class="actions" style="display:flex; gap:.5rem;">
-          <button class="button" onclick="downloadZip(currentJobId)">Télécharger en ZIP</button>
-          <button class="button ghost" onclick="downloadTxt(currentJobId, true)">Télécharger en TXT</button>
+        <div id="downloads" class="actions" style="gap:.5rem;" hidden>
+          <button class="button ghost" id="btn-transcription" onclick="downloadTxt(currentJobId, 'transcription', true)">Télécharger la transcription (TXT)</button>
+          <button class="button ghost" id="btn-summary" style="display:none;" onclick="downloadTxt(currentJobId, 'summary', true)">Télécharger le résumé (TXT)</button>
+          <button class="button" id="btn-zip" onclick="downloadZip(currentJobId)">Télécharger en ZIP</button>
         </div>
       </section>
     </main>


### PR DESCRIPTION
## Résumé
- Masque les boutons de téléchargement tant que le traitement n’est pas terminé
- Affiche le bouton de résumé uniquement en mode API lors du polling

## Tests
- `python -m py_compile server.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a7141f311c8333bf3ec2f82e7be7c0