### PR TITLE
fix: persist downloaded whisper models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # app-transcript
 transcrire mp3 vers txt
+
+Les modèles Whisper sont conservés dans `~/.cache/transcripteur-whisper/models` afin d'éviter de les télécharger à chaque lancement.
+Vous pouvez définir la variable d'environnement `WHISPER_MODELS_DIR` pour choisir un autre emplacement de stockage.

--- a/server.py
+++ b/server.py
@@ -45,7 +45,18 @@ UPLOAD_DIR = BASE_DIR / "uploads"
 TRANS_DIR  = BASE_DIR / "transcriptions"
 TEMP_DIR   = BASE_DIR / "tmp"
 ASSETS_DIR = BASE_DIR / "assets"
-MODELS_DIR = BASE_DIR / "models"   # <— on force le cache des modèles ici (pratique pour le .exe)
+
+# Répertoire persistant pour les modèles Whisper.
+# Peut être personnalisé via la variable d'environnement WHISPER_MODELS_DIR.
+def _get_models_dir() -> Path:
+    env = os.getenv("WHISPER_MODELS_DIR")
+    if env:
+        return Path(env).expanduser()
+    # Dossier par défaut dans ~/.cache pour éviter les redécoupages du one-file PyInstaller.
+    return Path.home() / ".cache" / "transcripteur-whisper" / "models"
+
+MODELS_DIR = _get_models_dir()
+
 for d in (UPLOAD_DIR, TRANS_DIR, TEMP_DIR, MODELS_DIR):
     d.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Summary
- store Whisper models in a stable cache directory
- allow overriding model cache location via `WHISPER_MODELS_DIR`
- document model cache behaviour

## Testing
- `python -m py_compile server.py main_gui.py`


------
https://chatgpt.com/codex/tasks/task_b_68a834b8e2c0833391dc35ed59e246f6